### PR TITLE
feat: expose thinking from Ollama chat chunks

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOllama/LmChatOllama.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOllama/LmChatOllama.node.test.ts
@@ -1,0 +1,13 @@
+import { ChatOllamaWithReasoning } from './LmChatOllama.node';
+
+describe('ChatOllamaWithReasoning', () => {
+	test('invocationParams sets think true without reasoning', () => {
+		const model = new ChatOllamaWithReasoning({
+			baseUrl: 'http://localhost:11434',
+			model: 'test-model',
+		});
+		const params = model.invocationParams({ think: true } as any);
+		expect(params.think).toBe(true);
+		expect('reasoning' in params).toBe(false);
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOllama/LmChatOllama.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOllama/LmChatOllama.node.ts
@@ -1,5 +1,13 @@
 import type { ChatOllamaInput } from '@langchain/ollama';
 import { ChatOllama } from '@langchain/ollama';
+import type { BaseMessage } from '@langchain/core/messages';
+import { AIMessageChunk } from '@langchain/core/messages';
+import { ChatGenerationChunk } from '@langchain/core/outputs';
+import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
+import {
+	convertOllamaMessagesToLangChain,
+	convertToOllamaMessages,
+} from '@langchain/ollama/dist/utils.js';
 import {
 	NodeConnectionTypes,
 	type INodeType,
@@ -13,6 +21,80 @@ import { getConnectionHintNoticeField } from '@utils/sharedFields';
 import { ollamaModel, ollamaOptions, ollamaDescription } from '../LMOllama/description';
 import { makeN8nLlmFailedAttemptHandler } from '../n8nLlmFailedAttemptHandler';
 import { N8nLlmTracing } from '../N8nLlmTracing';
+
+export class ChatOllamaWithReasoning extends ChatOllama {
+	invocationParams(options: this['ParsedCallOptions']) {
+		const params = super.invocationParams(options) as any;
+		const think = (options as any)?.think;
+		const reasoningEffort = (options as any)?.reasoningEffort;
+		if (think) {
+			params.think = true;
+			if (reasoningEffort) {
+				params.reasoning = reasoningEffort;
+			}
+		}
+		return params;
+	}
+
+	async *_streamResponseChunks(
+		messages: BaseMessage[],
+		options: this['ParsedCallOptions'],
+		runManager?: CallbackManagerForLLMRun,
+	): AsyncGenerator<ChatGenerationChunk> {
+		if (this.checkOrPullModel) {
+			if (!(await this.checkModelExistsOnMachine(this.model))) {
+				await this.pull(this.model, {
+					logProgress: true,
+				});
+			}
+		}
+		const params = this.invocationParams(options);
+		const ollamaMessages = convertToOllamaMessages(messages);
+		const usageMetadata = { input_tokens: 0, output_tokens: 0, total_tokens: 0 };
+		const stream = await this.client.chat({
+			...params,
+			messages: ollamaMessages,
+			stream: true,
+		});
+		let lastMetadata: Record<string, unknown> | undefined;
+		let lastThinking: string | undefined;
+		for await (const chunk of stream as AsyncIterable<any>) {
+			if (options.signal?.aborted) {
+				this.client.abort();
+			}
+			const { message: responseMessage, ...rest } = chunk as any;
+			const thinking = (responseMessage as any)?.thinking ?? (rest as any)?.thinking;
+			usageMetadata.input_tokens += rest.prompt_eval_count ?? 0;
+			usageMetadata.output_tokens += rest.eval_count ?? 0;
+			usageMetadata.total_tokens = usageMetadata.input_tokens + usageMetadata.output_tokens;
+			lastMetadata = rest;
+			if (thinking) {
+				lastThinking = thinking;
+			}
+			const lcMessage = convertOllamaMessagesToLangChain(responseMessage);
+			if (thinking) {
+				lcMessage.additional_kwargs = {
+					...lcMessage.additional_kwargs,
+					thinking,
+				};
+			}
+			yield new ChatGenerationChunk({
+				text: responseMessage.content ?? '',
+				message: lcMessage,
+			});
+			await runManager?.handleLLMNewToken(responseMessage.content ?? '');
+		}
+		yield new ChatGenerationChunk({
+			text: '',
+			message: new AIMessageChunk({
+				content: '',
+				additional_kwargs: lastThinking ? { thinking: lastThinking } : undefined,
+				response_metadata: lastMetadata,
+				usage_metadata: usageMetadata,
+			}),
+		});
+	}
+}
 
 export class LmChatOllama implements INodeType {
 	description: INodeTypeDescription = {
@@ -64,7 +146,7 @@ export class LmChatOllama implements INodeType {
 				}
 			: undefined;
 
-		const model = new ChatOllama({
+		const model = new ChatOllamaWithReasoning({
 			...options,
 			baseUrl: credentials.baseUrl as string,
 			model: modelName,


### PR DESCRIPTION
## Summary
- capture `thinking` from Ollama chat streaming chunks and attach it to message metadata
- surface `thinking` from the last chunk in the final AI message
- send `think: true` when enabled and optionally include `reasoning`
- cover invocation params when only `think` is requested

## Testing
- `pnpm --filter @n8n/n8n-nodes-langchain lint` *(fails: Cannot find module '/workspace/n8n/node_modules/@n8n/eslint-config/dist/configs/node.js')*
- `pnpm --filter @n8n/n8n-nodes-langchain test` *(fails: Cannot find module 'n8n-workflow' from many tests)*
- `pnpm --filter @n8n/n8n-nodes-langchain typecheck` *(fails: Cannot find module '@n8n/di' or 'n8n-workflow', plus implicit any errors)*

------
https://chatgpt.com/codex/tasks/task_e_689b2d8f8650832abdaca911f3107621