### PR TITLE
Fix reasoning effort parameter for OpenAI chat model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * **Google Gemini Node:** Don't pass hardcoded value for durationSeconds when generating a video ([#17793](https://github.com/n8n-io/n8n/issues/17793)) ([460e3b1](https://github.com/n8n-io/n8n/commit/460e3b1dfdb64bf4501dcf9ff1a480da34c64b6a))
 * **Google Sheets Node:** Make it possible to set cell values empty on updates ([#17224](https://github.com/n8n-io/n8n/issues/17224)) ([d924d82](https://github.com/n8n-io/n8n/commit/d924d82ee2862f398f66eb624815694893527d48))
 * Hide settings hint from log view ([#17813](https://github.com/n8n-io/n8n/issues/17813)) ([a46fa60](https://github.com/n8n-io/n8n/commit/a46fa6072e4d5bd02611625c60fe6fff7d31c731))
+* **OpenAI Chat Model Node:** Respect reasoning effort by passing the reasoning parameter correctly
 * **Microsoft Teams Trigger Node:** Forbidden when trying to listen for channel messages ([#17777](https://github.com/n8n-io/n8n/issues/17777)) ([bc97584](https://github.com/n8n-io/n8n/commit/bc97584c0c6e58878dd0e9708062813c099687a2))
 * **Stop and Error Node:** Show error message when error type is an object ([#17898](https://github.com/n8n-io/n8n/issues/17898)) ([aced4bf](https://github.com/n8n-io/n8n/commit/aced4bf86f343f768ddb81485c24e69d5cf12530))
 * **Structured Output Parser Node:** Handle passed objects that do not match schema ([#17774](https://github.com/n8n-io/n8n/issues/17774)) ([1fb78cb](https://github.com/n8n-io/n8n/commit/1fb78cb0eabfaedad16568e21254c42dae6cebee))

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
@@ -290,7 +290,7 @@ export class LmChatOpenAi implements INodeType {
 						],
 						displayOptions: {
 							show: {
-								// reasoning_effort is only available on o1, o1-versioned, or on o3-mini and beyond. Not on o1-mini or other GPT-models.
+								// reasoning is only available on o1, o1-versioned, or on o3-mini and beyond. Not on o1-mini or other GPT-models.
 								'/model': [{ _cnd: { regex: '(^o1([-\\d]+)?$)|(^o[3-9].*)' } }],
 							},
 						},
@@ -362,11 +362,11 @@ export class LmChatOpenAi implements INodeType {
 		// Extra options to send to OpenAI, that are not directly supported by LangChain
 		const modelKwargs: {
 			response_format?: object;
-			reasoning_effort?: 'low' | 'medium' | 'high';
+			reasoning?: { effort: 'low' | 'medium' | 'high' };
 		} = {};
 		if (options.responseFormat) modelKwargs.response_format = { type: options.responseFormat };
 		if (options.reasoningEffort && ['low', 'medium', 'high'].includes(options.reasoningEffort))
-			modelKwargs.reasoning_effort = options.reasoningEffort;
+			modelKwargs.reasoning = { effort: options.reasoningEffort };
 
 		const model = new ChatOpenAI({
 			openAIApiKey: credentials.apiKey as string,

--- a/packages/@n8n/nodes-langchain/nodes/llms/test/LMChatOpenAi.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/test/LMChatOpenAi.test.ts
@@ -1,0 +1,39 @@
+import { mock } from 'jest-mock-extended';
+import type { ISupplyDataFunctions } from 'n8n-workflow';
+
+import { LmChatOpenAi } from '../LMChatOpenAi/LmChatOpenAi.node';
+
+describe('LmChatOpenAi', () => {
+	const node = new LmChatOpenAi();
+
+	it.each([
+		{
+			name: 'no reasoning options',
+			options: {},
+			assert: (params: Record<string, unknown>) => {
+				expect(params).not.toHaveProperty('reasoning');
+			},
+		},
+		{
+			name: 'reasoning effort set',
+			options: { reasoningEffort: 'medium' },
+			assert: (params: Record<string, unknown>) => {
+				expect(params).toMatchObject({ reasoning: { effort: 'medium' } });
+			},
+		},
+	])('serializes correctly when $name', async ({ options, assert }) => {
+		const exec = mock<ISupplyDataFunctions>();
+		exec.getCredentials.mockResolvedValue({ apiKey: 'test' });
+		exec.getNode.mockReturnValue({ typeVersion: 1.2 });
+		exec.getNodeParameter.mockImplementation((name: string) => {
+			if (name === 'model.value') return 'o3-mini';
+			if (name === 'options') return options;
+			return undefined;
+		});
+
+		const result = await node.supplyData.call(exec, 0);
+		const params = (result.response as any).invocationParams({});
+
+		assert(params);
+	});
+});


### PR DESCRIPTION
## Summary
- pass reasoning parameter as `reasoning` object so OpenAI respects `reasoningEffort`
- add tests for reasoning parameter serialization
- document fix in changelog

## Testing
- `pnpm exec eslint -c packages/@n8n/nodes-langchain/eslint.config.mjs packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts packages/@n8n/nodes-langchain/nodes/llms/test/LMChatOpenAi.test.ts`
- `pnpm test --filter=@n8n/n8n-nodes-langchain`


------
https://chatgpt.com/codex/tasks/task_e_689b3f18776c832abca6baba163fb556